### PR TITLE
Support configuring per-field extraction strategies

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -3,7 +3,15 @@ llm:
   name: "deepseek-reasoner"
   temperature: 0.0
   top_p: 1.0
-
 browser:
   name: "chrome"
   wait_for_timeout: 1000
+fields:
+  article_body:
+    strategy: "xpath_extractor"
+  title:
+    strategy: "xpath_extractor"
+  author:
+    strategy: "lm_capabilities"
+  datetime:
+    strategy: "xpath_extractor"

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -10,8 +10,8 @@ fields:
   article_body:
     strategy: "xpath_extractor"
   title:
-    strategy: "xpath_extractor"
+    strategy: "lm_capabilities"
   author:
     strategy: "lm_capabilities"
   datetime:
-    strategy: "xpath_extractor"
+    strategy: "lm_capabilities"

--- a/langscrape/agent/tools.py
+++ b/langscrape/agent/tools.py
@@ -1,13 +1,56 @@
 # tools/store_xpath.py
+from typing import Any, Dict, List
+
 from langchain_core.tools import tool
+
+
+def _normalize_state_entry(state_dict: Dict[str, Any], key: str) -> Dict[str, Any]:
+    entry = state_dict.setdefault(key, {})
+    if not isinstance(entry, dict):
+        entry = {"strategy": "xpath_extractor", "xpath": entry}
+    entry.setdefault("strategy", "xpath_extractor")
+    state_dict[key] = entry
+    return entry
+
 
 def make_store_xpath(state_dict: dict):
     @tool
     def store_xpath(key: str, xpath: str):
-        """
-        Store a new XPath under a given key in the injected state_dict.
-        """
-        state_dict[key] = xpath
+        """Store a new XPath under a given key in the injected state_dict."""
+
+        entry = _normalize_state_entry(state_dict, key)
+        entry["strategy"] = entry.get("strategy", "xpath_extractor")
+        if entry["strategy"] != "xpath_extractor":
+            return (
+                f"Field '{key}' is configured for '{entry['strategy']}', so XPaths are ignored."
+            )
+
+        entry["xpath"] = xpath
+        entry.pop("value", None)
+        state_dict[key] = entry
         return f"Stored XPath for '{key}': {xpath}"
 
     return store_xpath
+
+
+def make_store_value(state_dict: dict):
+    @tool
+    def store_field_value(key: str, value: Any):
+        """Store a natural-language value for a field managed by the LLM."""
+
+        entry = _normalize_state_entry(state_dict, key)
+        entry["strategy"] = "lm_capabilities"
+
+        if isinstance(value, str):
+            values: List[str] = [value]
+        elif isinstance(value, list):
+            values = [str(v) for v in value if str(v).strip()]
+        else:
+            values = [str(value)]
+
+        entry["value"] = values
+        entry.pop("xpath", None)
+        state_dict[key] = entry
+        return f"Stored value for '{key}': {values}"
+
+    return store_field_value

--- a/langscrape/html/xpath_extractor.py
+++ b/langscrape/html/xpath_extractor.py
@@ -1,20 +1,81 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict, List, Optional
+
 from lxml import html as lxml_html
 
-def extract_by_xpath_map_from_html(html_content: str, xpath_map: dict[str, str]) -> dict[str, list[str]]:
-    """
-    Extracts content from HTML using a dict of XPath expressions.
-    Skips missing or invalid XPaths and returns trimmed text values.
-    """
-    tree = lxml_html.fromstring(html_content)
-    result = {}
 
-    for key, xp in xpath_map.items():
-        if not xp or not isinstance(xp, str) or xp.strip() == "":
+FieldState = Dict[str, Any]
+
+
+def _ensure_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        value = list(value)
+    else:
+        value = [value]
+
+    cleaned: List[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def _get_strategy(entry: Any) -> str:
+    if isinstance(entry, Mapping):
+        return str(entry.get("strategy", "xpath_extractor"))
+    return "xpath_extractor"
+
+
+def _get_xpath(entry: Any) -> Optional[str]:
+    if isinstance(entry, Mapping):
+        xpath = entry.get("xpath")
+    else:
+        xpath = entry
+    if isinstance(xpath, str):
+        xpath = xpath.strip()
+        return xpath or None
+    return None
+
+
+def extract_by_xpath_map_from_html(html_content: str, field_state: Dict[str, FieldState]) -> Dict[str, List[str]]:
+    """Extract structured content using field definitions.
+
+    Each field may either rely on an XPath expression (``xpath_extractor``)
+    or on previously stored natural-language values (``lm_capabilities``).
+    The helper gracefully handles both strategies, returning a map of
+    ``field -> list[str]`` for downstream formatting.
+    """
+
+    result: Dict[str, List[str]] = {}
+    tree = None
+
+    for key, entry in field_state.items():
+        strategy = _get_strategy(entry)
+
+        if strategy == "lm_capabilities":
+            values = []
+            if isinstance(entry, Mapping):
+                values = _ensure_list(entry.get("value"))
+            result[key] = values or ["(No stored value)"]
+            continue
+
+        xpath = _get_xpath(entry)
+        if not xpath:
             result[key] = ["Skipped: No XPath"]
             continue
 
+        if tree is None:
+            tree = lxml_html.fromstring(html_content)
+
         try:
-            values = tree.xpath(xp)
+            values = tree.xpath(xpath)
             clean_values = [
                 v.text_content().strip() if isinstance(v, lxml_html.HtmlElement) else str(v).strip()
                 for v in values

--- a/langscrape/printer.py
+++ b/langscrape/printer.py
@@ -10,7 +10,15 @@ def final_print(global_state, html_content):
 
     print(f"\n{BOLD}{BLUE}=== FINAL XPATH STATE ==={RESET}")
     for k, v in global_state.items():
-        print(f"{BLUE}{k}{RESET}: {v}")
+        if isinstance(v, dict):
+            strategy = v.get("strategy", "xpath_extractor")
+            if strategy == "lm_capabilities":
+                detail = v.get("value")
+            else:
+                detail = v.get("xpath")
+            print(f"{BLUE}{k}{RESET} ({strategy}): {detail}")
+        else:
+            print(f"{BLUE}{k}{RESET}: {v}")
 
     print(f"\n{BOLD}{GREEN}=== FINAL EXTRACTED CONTENT ==={RESET}")
     results = extract_by_xpath_map_from_html(html_content, xpath_map=global_state)

--- a/langscrape/printer.py
+++ b/langscrape/printer.py
@@ -21,7 +21,7 @@ def final_print(global_state, html_content):
             print(f"{BLUE}{k}{RESET}: {v}")
 
     print(f"\n{BOLD}{GREEN}=== FINAL EXTRACTED CONTENT ==={RESET}")
-    results = extract_by_xpath_map_from_html(html_content, xpath_map=global_state)
+    results = extract_by_xpath_map_from_html(html_content, field_state=global_state)
     for k, v in results.items():
         joined = " | ".join(v)
         print(f"{GREEN}{k}{RESET}: {joined}")

--- a/test.py
+++ b/test.py
@@ -2,16 +2,17 @@ import asyncio
 from langscrape import fetch_html_patchright, final_print
 from langscrape.agent.graph import get_graph
 from langscrape.html.utils import clean_html_for_extraction3
-from langscrape.agent.tools import make_store_xpath
-from langscrape.utils import load_config, get_llm
+from langscrape.agent.tools import make_store_xpath, make_store_value
+from langscrape.utils import load_config, get_llm, initialize_global_state
 
 config = load_config()
 
-global_state = {"article_body": None, "title": None, "author": None, "datetime": None}
+global_state = initialize_global_state(config)
 expected_fields = list(global_state.keys())
 
 store_xpath = make_store_xpath(global_state)
-tools = [store_xpath]
+store_field_value = make_store_value(global_state)
+tools = [store_xpath, store_field_value]
 graph = get_graph(tools=tools)
 
 llm = get_llm(config)


### PR DESCRIPTION
## Summary
- add field strategy metadata to the default configuration and initialize the agent state from it
- extend tooling and extraction utilities so fields can store XPath selectors or direct LLM values based on their strategy
- update prompts, printer output, and the sample entrypoint to respect the configured strategies

## Testing
- python -m compileall langscrape feilian test.py

------
https://chatgpt.com/codex/tasks/task_e_68de615a4be0832cb759998e5d1e8292