### PR TITLE
Add Flask-based batch extraction UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ Clone the repository:
 ```bash
 git clone https://github.com/DelmedigoA/langscrape.git
 cd langscrape
+
+## 🖥️ Interactive UI
+
+An experimental local UI is available for quickly testing batches of URLs and
+watching the extraction pipeline populate the desired fields in real time.
+
+1. Install the project dependencies and export the required LLM credentials
+   (e.g. `OPENAI_API_KEY` or `DS_API_KEY`).
+2. Launch the development server:
+
+   ```bash
+   python run_ui.py
+   ```
+
+3. Open <http://localhost:8000> in your browser, paste one URL per line into
+   the form, and press **Start Extraction**. The table begins with the URLs and
+   empty columns for the expected fields, then updates row-by-row as each
+   extraction finishes.

--- a/langscrape/webapp/__init__.py
+++ b/langscrape/webapp/__init__.py
@@ -1,0 +1,5 @@
+"""Web application entry points for the Langscrape UI."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/langscrape/webapp/app.py
+++ b/langscrape/webapp/app.py
@@ -1,0 +1,167 @@
+"""Flask application that powers the lightweight Langscrape UI."""
+
+from __future__ import annotations
+
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Dict, List, Optional
+
+from flask import Flask, jsonify, render_template, request
+
+from .pipeline import DEFAULT_FIELDS, run_extraction
+
+
+@dataclass
+class Record:
+    """Represents the extraction state for a single URL."""
+
+    url: str
+    fields: Dict[str, str] = field(default_factory=dict)
+    status: str = "pending"
+    error: Optional[str] = None
+
+
+@dataclass
+class Job:
+    """Tracks the lifecycle of a batch of URL extractions."""
+
+    id: str
+    urls: List[str]
+    records: List[Record]
+    status: str = "pending"
+    error: Optional[str] = None
+
+    def asdict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "error": self.error,
+            "records": [
+                {
+                    "url": record.url,
+                    "status": record.status,
+                    "error": record.error,
+                    "fields": record.fields,
+                }
+                for record in self.records
+            ],
+        }
+
+
+_executor: Optional[ThreadPoolExecutor] = None
+_jobs: Dict[str, Job] = {}
+_jobs_lock = Lock()
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(max_workers=2)
+    return _executor
+
+
+def _create_job(urls: List[str]) -> Job:
+    job_id = uuid.uuid4().hex
+    records = [
+        Record(
+            url=url,
+            fields={field: "" for field in DEFAULT_FIELDS},
+        )
+        for url in urls
+    ]
+    job = Job(id=job_id, urls=urls, records=records)
+    with _jobs_lock:
+        _jobs[job_id] = job
+    return job
+
+
+def _process_job(job_id: str) -> None:
+    from langscrape.utils import load_config, get_llm
+
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        return
+
+    with _jobs_lock:
+        job.status = "running"
+    config = None
+    try:
+        config = load_config()
+        llm = get_llm(config)
+    except Exception as exc:  # pragma: no cover - defensive guard for runtime issues
+        error_message = f"Failed to initialise LLM: {exc}".strip()
+        with _jobs_lock:
+            job.status = "failed"
+            job.error = error_message
+            for record in job.records:
+                record.status = "error"
+                record.error = error_message
+        return
+
+    has_error = False
+    for record in job.records:
+        with _jobs_lock:
+            record.status = "running"
+
+        try:
+            result = run_extraction(url=record.url, config=config, llm=llm)
+        except Exception as exc:  # pragma: no cover - runtime guard
+            has_error = True
+            message = str(exc)
+            with _jobs_lock:
+                record.status = "error"
+                record.error = message
+        else:
+            with _jobs_lock:
+                record.fields.update(result)
+                record.status = "completed"
+
+    with _jobs_lock:
+        job.status = "completed_with_errors" if has_error else "completed"
+        job.error = "Some URLs failed to process." if has_error else None
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(
+        __name__,
+        static_folder="static",
+        template_folder="templates",
+    )
+
+    @app.route("/")
+    def index():
+        return render_template("index.html", columns=DEFAULT_FIELDS)
+
+    @app.post("/api/jobs")
+    def create_job():
+        payload = request.get_json(force=True, silent=True) or {}
+        urls = payload.get("urls", [])
+        if not isinstance(urls, list):
+            return jsonify({"error": "`urls` must be an array of strings."}), 400
+
+        cleaned_urls = [url.strip() for url in urls if isinstance(url, str) and url.strip()]
+        if not cleaned_urls:
+            return jsonify({"error": "Please provide at least one URL."}), 400
+
+        job = _create_job(cleaned_urls)
+        executor = _get_executor()
+        executor.submit(_process_job, job.id)
+        return jsonify({"columns": DEFAULT_FIELDS, **job.asdict()}), 201
+
+    @app.get("/api/jobs/<job_id>")
+    def get_job(job_id: str):
+        with _jobs_lock:
+            job = _jobs.get(job_id)
+        if job is None:
+            return jsonify({"error": "Job not found."}), 404
+        return jsonify({"columns": DEFAULT_FIELDS, **job.asdict()})
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/langscrape/webapp/pipeline.py
+++ b/langscrape/webapp/pipeline.py
@@ -1,0 +1,61 @@
+"""Utility helpers for running Langscrape extractions from the UI."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from langscrape.agent.graph import get_graph
+from langscrape.agent.tools import make_store_xpath
+from langscrape.utils import get_llm, load_config
+
+DEFAULT_FIELDS: List[str] = [
+    "title",
+    "author",
+    "datetime",
+    "article_body",
+]
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, str)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+        return "\n\n".join(parts)
+    return str(value)
+
+
+def run_extraction(url: str, config: Optional[Dict[str, object]] = None, llm=None) -> Dict[str, str]:
+    """Execute the Langscrape pipeline for a single URL."""
+
+    if config is None:
+        config = load_config()
+
+    base_llm = llm or get_llm(config)
+
+    global_state = {field: None for field in DEFAULT_FIELDS}
+    store_xpath = make_store_xpath(global_state)
+    tools = [store_xpath]
+    graph = get_graph(tools=tools)
+
+    llm_with_tools = base_llm.bind_tools(tools)
+
+    initial_state = {
+        "messages": [],
+        "url": url,
+        "global_state": global_state,
+        "llm_with_tools": llm_with_tools,
+    }
+
+    final_state = graph.invoke(initial_state)
+    raw_result = final_state.get("result", {})
+
+    formatted: Dict[str, str] = {}
+    for field in DEFAULT_FIELDS:
+        formatted[field] = _stringify(raw_result.get(field))
+    return formatted
+
+
+__all__ = ["DEFAULT_FIELDS", "run_extraction"]

--- a/langscrape/webapp/templates/index.html
+++ b/langscrape/webapp/templates/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Langscrape UI</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.15/dist/tailwind.min.css"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        background: radial-gradient(circle at 20% 20%, #111827, #030712);
+        min-height: 100vh;
+      }
+      textarea::placeholder {
+        color: rgb(148 163 184);
+      }
+      .glass-card {
+        backdrop-filter: blur(18px);
+        background-color: rgba(15, 23, 42, 0.7);
+      }
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 9999px;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body class="text-slate-100">
+    <div class="py-12 px-4">
+      <div class="max-w-6xl mx-auto space-y-8">
+        <header class="glass-card shadow-2xl rounded-3xl p-10 border border-slate-800/60">
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p class="text-sm uppercase tracking-[0.4em] text-sky-400">Langscrape</p>
+              <h1 class="mt-3 text-3xl md:text-4xl font-semibold tracking-tight">
+                Batch HTML Extraction Playground
+              </h1>
+              <p class="mt-3 text-slate-300 max-w-2xl">
+                Paste one or more URLs, then watch the extraction pipeline populate the
+                structured fields in real time as the LLM iterates.
+              </p>
+            </div>
+            <div class="flex flex-col items-start md:items-end gap-2 text-sm">
+              <span class="uppercase text-slate-400 tracking-[0.3em]">Job Status</span>
+              <span id="jobStatus" class="status-pill bg-slate-800 text-slate-300">
+                Waiting to start
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <main class="glass-card shadow-2xl rounded-3xl border border-slate-800/60 overflow-hidden">
+          <div class="p-8 space-y-8">
+            <form id="urlForm" class="space-y-6">
+              <div class="space-y-3">
+                <label for="urlInput" class="block text-sm font-semibold tracking-wide text-slate-200 uppercase">Target URLs</label>
+                <textarea
+                  id="urlInput"
+                  name="urls"
+                  rows="5"
+                  class="w-full rounded-2xl border border-slate-700/80 bg-slate-900/70 px-5 py-4 text-base text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40 transition"
+                  placeholder="https://example.com/article-1\nhttps://example.com/article-2"
+                ></textarea>
+                <p class="text-sm text-slate-400">
+                  Enter one URL per line. The UI will create a row for each and stream updates as
+                  the extraction finishes.
+                </p>
+              </div>
+              <div class="flex flex-col sm:flex-row sm:items-center gap-4">
+                <button
+                  type="submit"
+                  class="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-sky-500 to-cyan-400 px-8 py-3 font-semibold text-slate-900 transition hover:shadow-lg hover:shadow-sky-500/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-400 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <svg
+                    id="loaderIcon"
+                    class="hidden h-4 w-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      class="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      stroke-width="4"
+                    ></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                    ></path>
+                  </svg>
+                  <span id="submitLabel">Start Extraction</span>
+                </button>
+                <span class="text-sm text-slate-400">Rows will update live as each URL completes.</span>
+              </div>
+            </form>
+
+            <div
+              id="alertBox"
+              class="hidden rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"
+            ></div>
+
+            <div class="rounded-2xl border border-slate-800/60 bg-slate-900/40 overflow-hidden">
+              <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-800 text-sm">
+                  <thead class="bg-slate-900/60">
+                    <tr>
+                      <th class="px-6 py-3 text-left font-semibold uppercase tracking-wider text-slate-300">URL</th>
+                      {% for column in columns %}
+                      <th class="px-6 py-3 text-left font-semibold uppercase tracking-wider text-slate-300">
+                        {{ column.replace('_', ' ') }}
+                      </th>
+                      {% endfor %}
+                      <th class="px-6 py-3 text-left font-semibold uppercase tracking-wider text-slate-300">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody id="resultsBody" class="divide-y divide-slate-800/60">
+                    <tr id="emptyState">
+                      <td colspan="{{ columns|length + 2 }}" class="px-6 py-10 text-center text-slate-400">
+                        Provide URLs above to kick off an extraction run.
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+
+    <script>
+      const columns = {{ columns | tojson }};
+      const urlForm = document.getElementById('urlForm');
+      const urlInput = document.getElementById('urlInput');
+      const resultsBody = document.getElementById('resultsBody');
+      const emptyState = document.getElementById('emptyState');
+      const alertBox = document.getElementById('alertBox');
+      const jobStatus = document.getElementById('jobStatus');
+      const loaderIcon = document.getElementById('loaderIcon');
+      const submitLabel = document.getElementById('submitLabel');
+
+      let currentJobId = null;
+      let pollHandle = null;
+
+      const statusStyles = {
+        pending: 'bg-slate-800 text-slate-300',
+        running: 'bg-blue-500/20 text-blue-200 border border-blue-400/40',
+        completed: 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/40',
+        completed_with_errors: 'bg-amber-500/20 text-amber-100 border border-amber-400/40',
+        error: 'bg-rose-500/20 text-rose-200 border border-rose-400/40',
+        failed: 'bg-rose-500/20 text-rose-200 border border-rose-400/40',
+      };
+
+      function toggleLoading(isLoading) {
+        if (isLoading) {
+          loaderIcon.classList.remove('hidden');
+          submitLabel.textContent = 'Starting…';
+        } else {
+          loaderIcon.classList.add('hidden');
+          submitLabel.textContent = 'Start Extraction';
+        }
+        urlForm.querySelector('button[type="submit"]').disabled = isLoading;
+      }
+
+      function showAlert(message) {
+        if (message) {
+          alertBox.textContent = message;
+          alertBox.classList.remove('hidden');
+        } else {
+          alertBox.textContent = '';
+          alertBox.classList.add('hidden');
+        }
+      }
+
+      function setJobStatus(status) {
+        const style = statusStyles[status] || statusStyles.pending;
+        jobStatus.textContent =
+          status === 'completed_with_errors'
+            ? 'Completed with warnings'
+            : status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+        jobStatus.className = `status-pill ${style}`;
+      }
+
+      function createCell(content, className = '') {
+        const cell = document.createElement('td');
+        cell.className = `px-6 py-4 align-top ${className}`;
+        cell.textContent = content;
+        return cell;
+      }
+
+      function createMultilineCell(content) {
+        const cell = document.createElement('td');
+        cell.className = 'px-6 py-4 text-slate-200 text-sm whitespace-pre-wrap max-w-xs';
+        cell.textContent = content || '';
+        return cell;
+      }
+
+      function renderRows(records) {
+        resultsBody.innerHTML = '';
+        if (!records.length) {
+          const row = document.createElement('tr');
+          const cell = document.createElement('td');
+          cell.colSpan = columns.length + 2;
+          cell.className = 'px-6 py-10 text-center text-slate-400';
+          cell.textContent = 'Provide URLs above to kick off an extraction run.';
+          row.appendChild(cell);
+          resultsBody.appendChild(row);
+          return;
+        }
+
+        records.forEach((record) => {
+          const row = document.createElement('tr');
+          row.className = 'hover:bg-slate-900/40 transition-colors';
+
+          row.appendChild(createCell(record.url, 'font-medium text-slate-100 break-all'));
+
+          columns.forEach((column) => {
+            row.appendChild(createMultilineCell(record.fields?.[column] || ''));
+          });
+
+          const statusCell = document.createElement('td');
+          statusCell.className = 'px-6 py-4';
+          const badge = document.createElement('span');
+          const style = statusStyles[record.status] || statusStyles.pending;
+          badge.className = `status-pill ${style}`;
+          badge.textContent =
+            record.status === 'error'
+              ? 'Error'
+              : record.status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+          statusCell.appendChild(badge);
+
+          if (record.error) {
+            const errorText = document.createElement('p');
+            errorText.className = 'mt-2 text-xs text-rose-200/80';
+            errorText.textContent = record.error;
+            statusCell.appendChild(errorText);
+          }
+
+          row.appendChild(statusCell);
+          resultsBody.appendChild(row);
+        });
+      }
+
+      async function pollJob(jobId) {
+        if (pollHandle) {
+          clearInterval(pollHandle);
+        }
+
+        const fetchStatus = async () => {
+          try {
+            const response = await fetch(`/api/jobs/${jobId}`);
+            if (!response.ok) {
+              const data = await response.json();
+              showAlert(data.error || 'Unable to fetch job status.');
+              clearInterval(pollHandle);
+              pollHandle = null;
+              toggleLoading(false);
+              return;
+            }
+            const data = await response.json();
+            renderRows(data.records || []);
+            setJobStatus(data.status);
+            if (data.status === 'completed' || data.status === 'completed_with_errors' || data.status === 'failed') {
+              clearInterval(pollHandle);
+              pollHandle = null;
+              toggleLoading(false);
+              if (data.status === 'failed') {
+                showAlert(data.error || 'Job failed.');
+              }
+            }
+          } catch (error) {
+            showAlert('Unable to connect to the server.');
+            clearInterval(pollHandle);
+            pollHandle = null;
+            toggleLoading(false);
+          }
+        };
+
+        await fetchStatus();
+        pollHandle = setInterval(fetchStatus, 2500);
+      }
+
+      urlForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        showAlert('');
+        const urls = urlInput.value
+          .split(/\n+/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+
+        if (!urls.length) {
+          showAlert('Please provide at least one URL.');
+          return;
+        }
+
+        toggleLoading(true);
+        setJobStatus('pending');
+
+        try {
+          const response = await fetch('/api/jobs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ urls }),
+          });
+
+          const data = await response.json();
+          if (!response.ok) {
+            showAlert(data.error || 'Unable to start extraction.');
+            toggleLoading(false);
+            return;
+          }
+
+          currentJobId = data.id;
+          renderRows(data.records || []);
+          setJobStatus(data.status);
+          await pollJob(currentJobId);
+        } catch (error) {
+          showAlert('Failed to reach the server.');
+          toggleLoading(false);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "IPython",
     "tokenizers",
     "langchain_deepseek",
+    "flask",
 ]
 
 [tool.setuptools.packages.find]

--- a/run_ui.py
+++ b/run_ui.py
@@ -1,0 +1,8 @@
+"""Helper script to launch the Langscrape UI locally."""
+
+from langscrape.webapp import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)


### PR DESCRIPTION
## Summary
- add a Flask application that manages URL batch extraction jobs and exposes JSON APIs for progress polling
- provide pipeline helpers and a Tailwind-styled template so users can queue URLs and watch table updates in real time
- document the new workflow and add a helper script plus dependency wiring for running the local UI

## Testing
- python -m compileall langscrape run_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68de6fa22018832c97b55b91bcf05d18