### PR TITLE
Refactor prompts into configurable templates

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -15,3 +15,125 @@ fields:
     strategy: "lm_capabilities"
   datetime:
     strategy: "lm_capabilities"
+prompts:
+  reasoner:
+    template: |
+      You are a ReAct-style HTML extraction agent.
+
+      GOAL:
+      Ensure each field has the correct extracted TEXT from the HTML.
+      XPath is just a tool; the objective is accurate content.
+
+      Reasoning Rules:
+      - **author** → should look like a human name, max 3-4 words.
+      - **article_body** → should be a long coherent article.
+      - **title** → should be a the article title.
+      - **datetime** → should look like a publication date or time.
+
+      ACTION POLICY:
+      For every field:
+      - Follow the field strategy declared below.
+      - If the field uses XPath and the extracted text is empty, irrelevant, too short, or violates the rules → call the tool:
+          store_xpath(key, new_xpath)
+        to propose a **better XPath**.
+      - If the field relies on LM Capabilities, store the final answer using:
+          store_field_value(key, value)
+      - If more than one cool tool is necessary, you should call multiple tools at a time.
+      - If all of the extraction looks plausible and correct → do nothing.
+      Stop when **all fields pass** these checks and LM fields have stored values.
+
+      When proposing XPath, follow these strict rules:
+      - Always use real tag names (div, section, span, time, h1, p, etc.)
+      - Never use class names as tag names.
+      - Use `contains(@class, '...')` to target classes.
+      - Always start with '//' or '/html' and separate each tag with '/'.
+
+      Example:
+      ✅ //section[contains(@class, 'article-body')]//p/text()
+      ❌ /html/body/main/article/section/article-details-body-container/article-body
+
+      CURRENT XPATH MAP:
+      {{xpath_snapshot}}
+
+      FIELD STRATEGIES:
+      {{field_strategies}}
+
+      CURRENT EXTRACTIONS SUMMARY:
+      {{formatted_extracts}}
+
+      HTML:
+      {{html_content}}
+  summarizer:
+    template: |
+      Analyze this content and extract specific metadata.
+
+      URL: {{url}}
+      Title: {{title}}
+      Author: {{author}}
+      Date: {{datetime}}
+      Content: {{content}}
+
+      Instructions:
+      1. For dates:
+      - Publication date: When the content was published
+      - Event date: When the described events occurred
+      - Use YYYY-MM-DD format
+      - For date ranges use: YYYY-MM-DD to YYYY-MM-DD
+      - If only month/year available, use first day: YYYY-MM-01
+      - If no date is available, return an empty string
+
+      2. For content type, classify as:
+      - Official Report: Research papers, formal investigations, detailed reports
+      - Official Statement: Press releases, announcements, declarations
+      - Opinion: Editorial content, opinion pieces, commentary
+      - Testimony: First-hand accounts, witness statements
+      - Journalistic Report: News articles, investigative journalism
+      - Analysis: Analysis, commentary
+      - Open letter: Letters to the editor, letters to the government, letters to the media
+      - News: Breaking news, time-sensitive reporting
+      - Post: Social media posts, short updates
+
+      3. For media type, classify as:
+      - Video: Video content, broadcasts
+      - Photo: Photo galleries, image-focused content
+      - Audio: Audio content, podcasts
+      - Text: Text content, articles, reports
+
+      4. For tags:
+      - IMPORTANT: You must ONLY use tags from the following list. DO NOT create any new tags:
+      {{allowed_tags}}
+      - Select ONLY the most relevant tags from this list that are reflected in the content
+      - Format as an array of strings
+      - If no tags from the list apply, return an empty array
+
+      Return a JSON object with these exact fields:
+
+      {
+          "summary": "One clear, informative sentence summarizing the main content",
+          "date_published": "YYYY-MM-DD",
+          "event_date": "YYYY-MM-DD or YYYY-MM-DD to YYYY-MM-DD",
+          "type": "One of the content types listed above",
+          "media": "One of the media types listed above",
+          "language": "The primary language of the content",
+          "platform": "The website or platform where content is published",
+          "author": "The content author or organization",
+          "tags": ["relevant", "topic", "tags"]
+      }
+      - All string values (including "summary" and "tags") **must be in English**.
+
+      Important
+      - Even if the content is in non-english language (e.g: Hebrew, French etc...) your output should be in *English*.
+      - Extract information only from the provided content
+      - Leave field empty ("") if information is not explicitly present
+      - For platform, extract from the URL or content source
+      - For language, specify if clearly identifiable
+      - Tags should ONLY be from the provided list, do not create new ones
+      - Search for publication date in the content's metadata
+      - If no publication date is found, use the creation date of the content
+      - Always return content processed in English
+    field_mapping:
+      title: "title"
+      content: "article_body"
+      author: "author"
+      datetime: "datetime"
+    allowed_tags_module: "config.allowed_tags:ALLOWED_TAGS"

--- a/langscrape/nodes/summarizer_prompt_builder.py
+++ b/langscrape/nodes/summarizer_prompt_builder.py
@@ -1,576 +1,81 @@
-from langchain_core.messages import SystemMessage
-from ..html.xpath_extractor import extract_by_xpath_map_from_html
+from importlib import import_module
+from typing import Any, Dict
+
 from ..agent.state import AgentState
-from ..utils import get_system_prompt, get_formatted_extracts, get_llm
-from ..utils import load_config
+from ..utils import (
+    DEFAULT_SUMMARIZER_TEMPLATE,
+    get_llm,
+    load_config,
+    render_prompt_template,
+)
 
-ALLOWED_TAGS = [
-                # Theme tags
-                "2000 Pound Bomb",  
-                "Abduction",
-                "Abuse",
-                "Academia",
-                "Accountability",
-                "Administrative Detention",
-                "Advertisement",
-                "Agriculture",
-                "AI (Artificial Intelligence)",
-                "Aid Distribution",
-                "Aid Workers",
-                "Airdrops",
-                "Air Strike",
-                "Amalek",
-                "American Society",
-                "Amputation",
-                "Analysis",
-                "Animals",
-                "Annexation",
-                "Antisemitism",
-                "Apartheid",    
-                "Appeal to World Leaders",
-                "Archaeological Findings",
-                "Arms Shipments",
-                "Arrest",
-                "Assassination",
-                "Attacks on Aid Centers",
-                "Attacks on Police",
-                "Blockade",
-                "Blocking Aid",
-                "Bombing",
-                "Books",
-                "Buildings",
-                "Burial",
-                "Burn Injuries",
-                "Burning",
-                "Cages",
-                "Campaign against UNRWA",
-                "Campus Protests",
-                "Captivity Conditions", 
-                "Ceasefire",
-                "Cemetery",
-                "Censorship",
-                "Children",
-                "Civilians",
-                "Collective Punishment",
-                "Combat Footage",
-                "Communication Blackout",
-                "Conscientious Objection",
-                "Confiscated Assets",
-                "Conspiracy Theories",
-                "Cooking Gas",
-                "Corpses",
-                "Corruption",
-                "Crimes Against Humanity",
-                "Cultural Genocide",
-                "Death",
-                "Debunked",
-                "Dehumanization",
-                "Demolition",
-                "Destruction",
-                "Destruction of Cultural Sites",
-                "Detainees",
-                "Detention Center",
-                "Diplomacy",
-                "Disability",
-                "Disease",      
-                "Disengagement (2005)",
-                "Disturbing Content",
-                "Domicide",
-                "Double Tap Strike", 
-                "Doubting the Gaza Death Toll",
-                "Drone / Quadcopter",
-                "Economy",
-                "Education",
-                "Elderly",  
-                "Electricity",
-                "Emigration",
-                "Ethnic Cleansing",
-                "Execution",    
-                "Explosives",
-                "Explosive Injuries",
-                "Family",
-                "Famine",
-                "Food",
-                "Fuel",
-                "Funding",
-                "Forced Displacement",
-                "Gaza Death Toll",
-                "Gaza US Pier",
-                "Genocide",
-                "Geolocation",      
-                "Global Comparisons",
-                "Ground Operation",
-                "Gunshot Wounds",
-                "Hannibal Directive",
-                "Healthcare Workers",
-                "Hospital",
-                "Hospital Conditions",
-                "Hostage Deal",
-                "Hostage Rescue Operation",
-                "Hostages",
-                "Human Shields",
-                "Humanitarian Aid",
-                "Humanitarian Crisis",
-                "Humanitarian Law",
-                "Humiliation",
-                "Hygiene Issues",
-                "Incitement to Genocide",
-                "Incitement to Violence",
-                "Indiscriminate Shooting",
-                "Infants",
-                "Infrastructure",
-                "Injury",
-                "International Responsibility",
-                "International Sanctions",
-                "Interview",
-                "Iron Dome",
-                "Islamophobia",
-                "Israeli Education System",
-                "Israeli Far Right",
-                "Israeli Media",
-                "Israeli Negotiation Team",
-                "Israeli Political Right",
-                "Israeli Society",
-                "Israeli Soldier Movies",
-                "Israeli Soldier Photos",
-                "Israeli Soldier Testimonies",
-                "Jewish Settlements in Gaza",
-                "Journalistic Report",
-                "Journalists",
-                "Leahy Law",
-                "Limiting Free Speech",
-                "Looting",
-                "Malnutrition",
-                "Massacres",
-                "Mass Casualty",
-                "Mass Graves",
-                "Mass Killing",
-                "Media",
-                "Media Bias",
-                "Medical Equipment",
-                "Medical Supplies",
-                "Medicine",
-                "Military Bases",
-                "Military Correspondent",
-                "Misleading/Partially False",
-                "Mockery",
-                "Mortar",
-                "Mosques",
-                "Murder",
-                "Nakba",
-                "News",
-                "Occupied Territories",
-                "October 7th 2023",
-                "Official Report",
-                "Official Statement",
-                "Open Letter",
-                "Opinion",
-                "Orphans",
-                "Palestinian Citizens of Israel",
-                "Palestinian Militants",
-                "Palestinian Testimony",
-                "Poll",
-                "Poverty",
-                "Pregnancy",
-                "Prisoners",
-                "Propaganda",
-                "Protest (International)",
-                "Protest (Israel)",
-                "Protest (Palestinians)",
-                "Psychological Trauma",
-                "Psychological Warfare",
-                "Public Debate",
-                "Public Health",
-                "Public Opinion",
-                "Quantitative Data",
-                "Quran",
-                "Racism",
-                "Reconstruction",
-                "Rafah Red Line",
-                "Refugees",
-                "Religious Right",
-                "Rubble",
-                "Rules of Engagement",
-                "Running Over",
-                "Safe Zones",
-                "Sanitation",
-                "Satellite images",
-                "Scholasticide",
-                "Schools",
-                "Settlements",
-                "Settlers Violence",
-                "Severe Illnesses",
-                "Sexual Violence",
-                "Shooting",
-                "Snipers",
-                "Social Media",
-                "Starvation",
-                "Summer Conditions",
-                "Surveillance",
-                "Talkbacks",
-                "Tanks",
-                "Terrorism",
-                "Testimony",
-                "The Flour Massacre",
-                "The Generals' Plan",
-                "Torching Houses",
-                "Torture",
-                "Toys",
-                "Two State Solution",
-                "Universities",
-                "Urbicide",
-                "US-Israeli Relations",
-                "US Military Aid",
-                "Vandalism",
-                "Video Games",
-                "Violence",
-                "War Crimes",
-                "Warning",
-                "Water",
-                "WCNSF (Wounded Child No Surviving Family)",
-                "Winter conditions",
-                "Women",
-                "Women's clothing (inc. lingerie)",
 
-                # Countries & Organizations
-                "AIPAC (American Israel Public Affairs Committee)",
-                "ACRI (The association for Civil Rights in Israel)",
-                "Al Jazeera",
-                "Al-Azhar University",
-                "Amnesty International",
-                "Australia",
-                "Bar-Ilan University",
-                "Begin-Sadat Center for Strategic Studies",
-                "COGAT (The Coordination of the Israeli Government Activities in the Territories)",
-                "Columbia University",
-                "Egypt",
-                "Elbit",
-                "EU (European Union)",
-                "FAJR Scientific",
-                "FAO (The Food and Agriculture Organization of the United Nations)",
-                "Foundation for the Defense of Democracies",
-                "Gaza Health Ministry",
-                "Gaza Police",
-                "Germany",
-                "Gisha",
-                "Hamas",
-                "HaMoked Center for the Defense of the Individual",
-                "Hezbollah",
-                "Hind Rajab Foundation",
-                "Hostages and Missing Families Forum",
-                "Houthis (Ansar Allah)",
-                "Human Rights Watch",
-                "IDF (Israel Defense Forces)",
-                "ICC (International Criminal Court)",
-                "ICJ (International Court of Justice)",
-                "ICRC (International Committee of the Red Cross)",
-                "Iran",
-                "IRC (International Rescue Committee)",
-                "Islamic Jihad",
-                "Israel Antiquities Authority",
-                "Israeli Education Ministry",
-                "Israeli Foreign Ministry",
-                "Israeli Government",
-                "Israeli Health Ministry",
-                "Israeli Incarceration System",
-                "Israeli Parliament (Knesset)",
-                "Israeli Police",
-                "Israeli Prison",
-                "Israeli Supreme Court",
-                "Jerusalem Institute for Strategy and Security",
-                "Jordan",
-                "JVP (Jewish Voice for Peace)",
-                "Lebanon",
-                "Likud",
-                "MAP (Medical Aid for Palestinians)",
-                "Meta Platforms",
-                "Mossad",
-                "MSF - Médecins Sans Frontières (Doctors Without Borders)",
-                "Nachala (settler movement)",
-                "Norwegian Refugee Council",
-                "OCHA (UN Office for the Coordination of Humanitarian Affairs)",
-                "Palestinian Authority",
-                "PAMA (Palestinian American Medical Association)",
-                "PCD (Palestinian Civil Defence)",
-                "Physicians for Human Rights Israel",
-                "Palestinian Ministry of Education",
-                "PRCS (Palestinian Red Crescent Society)",
-                "Project HOPE",
-                "Qatar",
-                "Saudi Arabia",
-                "Shin Bet",
-                "South Africa",
-                "Syria",
-                "Tsav 9",
-                "UN (United Nations)",
-                "UNESCO (United Nations Educational, Scientific and Cultural Organization)",
-                "UNFPA (United Nations Population Fund)",
-                "UNICEF (United Nations Children's Fund)",
-                "United Kingdom",
-                "United States",
-                "UNRWA (The UN Relief and Works Agency for Palestine Refugees)",
-                "UN Security Council",
-                "USAID (United States Agency for International Development)",
-                "US Department of State",
-                "Vatican",
-                "WHO (World Health Organization)",
-                "World Central Kitchen",
-                "World Food Programme",
-                "Zazim",
+def _load_allowed_tags(summarizer_config: Dict[str, Any]) -> Any:
+    if "allowed_tags" in summarizer_config:
+        return summarizer_config.get("allowed_tags") or []
 
-                #Locations
-                "Al Ahli Baptist Hospital"
-                "Al-Amal Hospital",
-                "Al-Aqsa Hospital",
-                "Al Aqsa University",
-                "Al-Awda Hospital",
-                "Al Azhar University",
-                "Al Buriej",
-                "Al Mawasi",
-                "Al Nazla",
-                "Al-Rantisi Hospital",
-                "Al Rashid Coastal Road",
-                "Al-Shati Refugee Camp",
-                "Al-Shifa Hospital",
-                "Al Yarmouk Stadium Refugee Camp",
-                "Al-Yemen Al-Saeed Hospital",
-                "Ashdod Port",
-                "Beer Sheva",
-                "Beit Hanoun",
-                "Beit Lahiya",
-                "Central Gaza Strip",
-                "Central Israel",
-                "Cyprus",
-                "Damon Prison",
-                "Deir al Balah",
-                "East Jerusalem",
-                "Egypt",
-                "Erez Crossing",
-                "Europe",
-                "Gaza City",
-                "Gaza Strip",
-                "Gilboa Prison",
-                "Hebron",
-                "Iran",
-                "Iraq",
-                "Israel",
-                "Israeli Parliament (Knesset)",
-                "Israeli Prison",
-                "Jabaliya",
-                "Jabaliya Camp",
-                "Jabaliya City",
-                "Jericho",
-                "Jerusalem",
-                "Jordan",
-                "Jordan Valley",
-                "Kamal Adwan Hospital",
-                "Karni Crossing",
-                "Kerem Shalom Crossing",
-                "Khan Younis",
-                "Khuza'a",
-                "Ktzi'ot Prison",
-                "Lebanon",
-                "Megido Prison",
-                "Mohammed Yousef El-Najar Hospital",
-                "Morag Corridor",
-                "Nablus",
-                "Nasser Hospital",
-                "Negev",
-                "Netzarim Corridor",
-                "Nitzana Border Crossing",
-                "North Gaza",
-                "Northern Israel",
-                "Nur Shams Refugee Camp",
-                "Nuseirat Refugee Camp",
-                "Philadelphi Corridor",
-                "Qalqilya",
-                "Qatar",
-                "Rafah",
-                "Rafah Crossing",
-                "Ramallah",
-                "Red Cross Field Hospital",
-                "Sde Teiman Detention Center",
-                "Sheikh Radwan",
-                "Shujjaiya",
-                "South Gaza",
-                "Southern Israel",
-                "Tel Aviv",
-                "The European Hospital",
-                "The Indonesian Hospital",
-                "Tul Karem",
-                "Turkish-Palestinian Friendship Hospital",
-                "USA",
-                "West Bank",
-                "Western Negev (Otef)",
-                "Zaytun Neighborhood",
-                "Zikim Crossing",
+    module_path = summarizer_config.get("allowed_tags_module")
+    if module_path:
+        module_name, _, attr = module_path.partition(":")
+        try:
+            module = import_module(module_name)
+            attr_name = attr or "ALLOWED_TAGS"
+            return getattr(module, attr_name)
+        except (ModuleNotFoundError, AttributeError) as exc:
+            raise ValueError(
+                f"Unable to load allowed tags from '{module_path}'."
+            ) from exc
 
-                # Figures
-                "Aaron Bushnell",
-                "Ahmad Tibi",
-                "Almog Boker",
-                "Almog Cohen",
-                "Amihai Eliyahu",
-                "Amit Segal",
-                "António Guterres",
-                "Antony Blinken",
-                "Avichay Adraee",
-                "Benjamin Netanyahu",
-                "Benny Gantz",
-                "Benny Morris",
-                "Bezalel Smotritch",
-                "Cochav Elkayam-Levy",
-                "Daniel Hagari",
-                "Daniella Weiss",
-                "Danny Danon",
-                "David Barnea",
-                "Donald Trump",
-                "Dr Adnan Al Bursh",
-                "Dr Hussam Abu Safiya",
-                "Dr Marwan Shafiq Alhamss",
-                "Efraim Inbar",
-                "Eitan Shamir",
-                "Francesca Albanese",
-                "Gali Baharav-Miara",
-                "Giora Eiland",
-                "Guy Basson",
-                "Guy Hochman",
-                "Hassan Nasrallah",
-                "Herzi Halevi",
-                "Hossam Shabat",
-                "Isaac Herzog",
-                "Ismail Haniyeh",
-                "Israel Katz",
-                "Itamar Ben-Gvir",
-                "James Elder",
-                "Jake Sullivan",
-                "Jibril Ghatab El-Kahlout",
-                "Joe Biden",
-                "John Kirby",
-                "Joseph Borrell",
-                "Kamala Harris",
-                "Karim Khan",
-                "Kobi Yaakobi",
-                "Lloyd Austin",
-                "Mahmoud Abbas",
-                "May Golan",
-                "Merav Michaeli",
-                "Martin Shaw",
-                "Marwan Barghouti",
-                "Mohammed bin Salman Al Saud",
-                "Mosab Abu Toha",
-                "Moshe (Bogie) Yaalon",
-                "Moshe Feiglin",
-                "Mustafa Jamal Kahlout",
-                "Naftali Bennett",
-                "Nisim Vatouri",
-                "Nitzan Alon",
-                "Nir Barkat",
-                "Noam Tibon",
-                "Ofer Cassif",
-                "Omer Bar-Lev",
-                "Philippe Lazzarini",
-                "Pope Francis",
-                "Ron Dermer",
-                "Ronen Bar",
-                "Sarah Netanyahu",
-                "Shimon Boker",
-                "Shimon Riklin",
-                "Tali Gotliv",
-                "Volker Türk",
-                "Yaakov Bardugo",
-                "Yahya Al-Sinwar",
-                "Yair Golan",
-                "Yair Lapid",
-                "Yehuda Schlesinger",
-                "Yehudah Vach",
-                "Yehuda Vald",
-                "Yinon Magal",
-                "Yoav Gallant",
-                "Zvi Sukkot",
-                "Zvi Yehezkeli",
-            ]   
-            
+    try:
+        module = import_module("config.allowed_tags")
+        return getattr(module, "ALLOWED_TAGS")
+    except ModuleNotFoundError:
+        return []
 
-def get_prompt(state: AgentState):
-    url = state["url"]
-    extracted_data = state["result"]
-    url = state["url"]
-    title = extracted_data["title"]
-    content = extracted_data["article_body"]
-    author = extracted_data["author"]
-    datetime = extracted_data["datetime"]
-    prompt_template = f"""Analyze this content and extract specific metadata.
 
-    URL: {url}
-    Title: {title}
-    Author: {author}
-    Date: {datetime}
-    Content: {content}
+def _resolve_field_mapping(
+    extracted_data: Dict[str, Any],
+    mapping: Dict[str, str],
+) -> Dict[str, Any]:
+    resolved = {}
+    for placeholder, field_name in mapping.items():
+        resolved[placeholder] = extracted_data.get(field_name, "")
+    return resolved
 
-    Instructions:
-    1. For dates:
-    - Publication date: When the content was published
-    - Event date: When the described events occurred
-    - Use YYYY-MM-DD format
-    - For date ranges use: YYYY-MM-DD to YYYY-MM-DD
-    - If only month/year available, use first day: YYYY-MM-01
-    - If no date is available, return an empty string
 
-    2. For content type, classify as:
-    - Official Report: Research papers, formal investigations, detailed reports
-    - Official Statement: Press releases, announcements, declarations
-    - Opinion: Editorial content, opinion pieces, commentary
-    - Testimony: First-hand accounts, witness statements
-    - Journalistic Report: News articles, investigative journalism
-    - Analysis: Analysis, commentary
-    - Open letter: Letters to the editor, letters to the government, letters to the media
-    - News: Breaking news, time-sensitive reporting
-    - Post: Social media posts, short updates
+def get_prompt(state: AgentState, config: Dict[str, Any] | None = None) -> str:
+    if config is None:
+        config = load_config()
+    prompts_config = config.get("prompts") or {}
+    summarizer_config = prompts_config.get("summarizer", {})
 
-    3. For media type, classify as:
-    - Video: Video content, broadcasts
-    - Photo: Photo galleries, image-focused content
-    - Audio: Audio content, podcasts
-    - Text: Text content, articles, reports
+    template = summarizer_config.get("template", DEFAULT_SUMMARIZER_TEMPLATE)
 
-    4. For tags:
-    - IMPORTANT: You must ONLY use tags from the following list. DO NOT create any new tags:
-    {ALLOWED_TAGS}
-    - Select ONLY the most relevant tags from this list that are reflected in the content
-    - Format as an array of strings
-    - If no tags from the list apply, return an empty array
+    default_mapping = {
+        "title": "title",
+        "content": "article_body",
+        "author": "author",
+        "datetime": "datetime",
+    }
+    field_mapping = summarizer_config.get("field_mapping", default_mapping)
 
-    Return a JSON object with these exact fields:
-    
-    {{
-        "summary": "One clear, informative sentence summarizing the main content",
-        "date_published": "YYYY-MM-DD",
-        "event_date": "YYYY-MM-DD or YYYY-MM-DD to YYYY-MM-DD",
-        "type": "One of the content types listed above",
-        "media": "One of the media types listed above",
-        "language": "The primary language of the content",
-        "platform": "The website or platform where content is published",
-        "author": "The content author or organization",
-        "tags": ["relevant", "topic", "tags"]
-    }}
-    - All string values (including "summary" and "tags") **must be in English**.
-    
-    Important
-    - Even if the content is in non-english language (e.g: Hebrew, French etc...) your output should be in *English*.
-    - Extract information only from the provided content
-    - Leave field empty ("") if information is not explicitly present
-    - For platform, extract from the URL or content source
-    - For language, specify if clearly identifiable
-    - Tags should ONLY be from the provided list, do not create new ones
-    - Search for publication date in the content's metadata
-    - If no publication date is found, use the creation date of the content
-    - Always return content processed in English
-    """
-    return prompt_template
+    extracted_data = state.get("result", {})
+    dynamic_fields = _resolve_field_mapping(extracted_data, field_mapping)
+
+    context = {
+        "url": state.get("url", ""),
+        **dynamic_fields,
+        "allowed_tags": _load_allowed_tags(summarizer_config),
+    }
+
+    context.update(summarizer_config.get("context", {}))
+
+    return render_prompt_template(template, context)
+
 
 def summarizer(state: AgentState) -> AgentState:
-    state["summarizer"] = get_llm()
-    prompt = get_prompt(state)
+    config = load_config()
+    state["summarizer"] = get_llm(config)
+    prompt = get_prompt(state, config)
     state["summary"] = state["summarizer"].invoke(prompt)
     return state

--- a/langscrape/utils.py
+++ b/langscrape/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict
 
@@ -8,13 +9,143 @@ from langchain_deepseek import ChatDeepSeek
 from langchain_core.messages import SystemMessage
 from langchain_openai import ChatOpenAI
 
+DEFAULT_REASONER_TEMPLATE = """You are a ReAct-style HTML extraction agent.
+
+GOAL:
+Ensure each field has the correct extracted TEXT from the HTML.
+XPath is just a tool; the objective is accurate content.
+
+Reasoning Rules:
+- **author** → should look like a human name, max 3-4 words.
+- **article_body** → should be a long coherent article.
+- **title** → should be a the article title.
+- **datetime** → should look like a publication date or time.
+
+ACTION POLICY:
+For every field:
+- Follow the field strategy declared below.
+- If the field uses XPath and the extracted text is empty, irrelevant, too short, or violates the rules → call the tool:
+    store_xpath(key, new_xpath)
+  to propose a **better XPath**.
+- If the field relies on LM Capabilities, store the final answer using:
+    store_field_value(key, value)
+- If more than one cool tool is necessary, you should call multiple tools at a time.
+- If all of the extraction looks plausible and correct → do nothing.
+Stop when **all fields pass** these checks and LM fields have stored values.
+
+When proposing XPath, follow these strict rules:
+- Always use real tag names (div, section, span, time, h1, p, etc.)
+- Never use class names as tag names.
+- Use `contains(@class, '...')` to target classes.
+- Always start with '//' or '/html' and separate each tag with '/'.
+
+Example:
+✅ //section[contains(@class, 'article-body')]//p/text()
+❌ /html/body/main/article/section/article-details-body-container/article-body
+
+CURRENT XPATH MAP:
+{{xpath_snapshot}}
+
+FIELD STRATEGIES:
+{{field_strategies}}
+
+CURRENT EXTRACTIONS SUMMARY:
+{{formatted_extracts}}
+
+HTML:
+{{html_content}}
+"""
+
+DEFAULT_SUMMARIZER_TEMPLATE = """Analyze this content and extract specific metadata.
+
+URL: {{url}}
+Title: {{title}}
+Author: {{author}}
+Date: {{datetime}}
+Content: {{content}}
+
+Instructions:
+1. For dates:
+- Publication date: When the content was published
+- Event date: When the described events occurred
+- Use YYYY-MM-DD format
+- For date ranges use: YYYY-MM-DD to YYYY-MM-DD
+- If only month/year available, use first day: YYYY-MM-01
+- If no date is available, return an empty string
+
+2. For content type, classify as:
+- Official Report: Research papers, formal investigations, detailed reports
+- Official Statement: Press releases, announcements, declarations
+- Opinion: Editorial content, opinion pieces, commentary
+- Testimony: First-hand accounts, witness statements
+- Journalistic Report: News articles, investigative journalism
+- Analysis: Analysis, commentary
+- Open letter: Letters to the editor, letters to the government, letters to the media
+- News: Breaking news, time-sensitive reporting
+- Post: Social media posts, short updates
+
+3. For media type, classify as:
+- Video: Video content, broadcasts
+- Photo: Photo galleries, image-focused content
+- Audio: Audio content, podcasts
+- Text: Text content, articles, reports
+
+4. For tags:
+- IMPORTANT: You must ONLY use tags from the following list. DO NOT create any new tags:
+{{allowed_tags}}
+- Select ONLY the most relevant tags from this list that are reflected in the content
+- Format as an array of strings
+- If no tags from the list apply, return an empty array
+
+Return a JSON object with these exact fields:
+
+{
+    "summary": "One clear, informative sentence summarizing the main content",
+    "date_published": "YYYY-MM-DD",
+    "event_date": "YYYY-MM-DD or YYYY-MM-DD to YYYY-MM-DD",
+    "type": "One of the content types listed above",
+    "media": "One of the media types listed above",
+    "language": "The primary language of the content",
+    "platform": "The website or platform where content is published",
+    "author": "The content author or organization",
+    "tags": ["relevant", "topic", "tags"]
+}
+- All string values (including "summary" and "tags") **must be in English**.
+
+Important
+- Even if the content is in non-english language (e.g: Hebrew, French etc...) your output should be in *English*.
+- Extract information only from the provided content
+- Leave field empty ("") if information is not explicitly present
+- For platform, extract from the URL or content source
+- For language, specify if clearly identifiable
+- Tags should ONLY be from the provided list, do not create new ones
+- Search for publication date in the content's metadata
+- If no publication date is found, use the creation date of the content
+- Always return content processed in English
+"""
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{\{\s*([a-zA-Z0-9_]+)\s*\}\}")
+
+
 def load_config(path: str = "config/default_config.yaml") -> dict:
-    """
-    Load YAML config into a Python dict.
-    """
+    """Load YAML config into a Python dict."""
     with open(Path(path), "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
-    
+
+
+def render_prompt_template(template: str, context: Dict[str, Any]) -> str:
+    """Replace ``{{placeholder}}`` tokens with values from ``context``."""
+
+    def _replacement(match: re.Match) -> str:
+        key = match.group(1).strip()
+        value = context.get(key, "")
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, ensure_ascii=False, indent=2)
+        return str(value)
+
+    return _PLACEHOLDER_PATTERN.sub(_replacement, template)
+
+
 def get_llm(config=None):
     if config is None:
         config = load_config()
@@ -37,6 +168,7 @@ def get_llm(config=None):
         )
     else:
         raise NameError(f"{config['llm']['type']} is not supported. try")
+
 
 def initialize_global_state(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     field_definitions = config.get("fields", {}) or {}
@@ -77,54 +209,28 @@ def _format_xpath_snapshot(global_state: Dict[str, Dict[str, Any]]) -> str:
 
 
 def get_system_prompt(state, formatted_extracts):
-    return SystemMessage(
-        content=f"""You are a ReAct-style HTML extraction agent.
+    config = state.get("config") if isinstance(state, dict) else None
+    if config is None:
+        config = load_config()
 
-GOAL:
-Ensure each field has the correct extracted TEXT from the HTML.
-XPath is just a tool; the objective is accurate content.
+    prompts_config = (config.get("prompts") or {})
+    reasoner_config = prompts_config.get("reasoner", {})
+    template = reasoner_config.get("template", DEFAULT_REASONER_TEMPLATE)
 
-Reasoning Rules:
-- **author** → should look like a human name, max 3-4 words.
-- **article_body** → should be a long coherent article.
-- **title** → should be a the article title.
-- **datetime** → should look like a publication date or time.
-
-ACTION POLICY:
-For every field:
-- Follow the field strategy declared below.
-- If the field uses XPath and the extracted text is empty, irrelevant, too short, or violates the rules → call the tool:
-    store_xpath(key, new_xpath)
-  to propose a **better XPath**.
-- If the field relies on LM Capabilities, store the final answer using:
-    store_field_value(key, value)
-- If more than one cool tool is necessary, you should call multiple tools at a time.
-- If all of the extraction looks plausible and correct → do nothing.
-Stop when **all fields pass** these checks and LM fields have stored values.
-
-When proposing XPath, follow these strict rules:
-- Always use real tag names (div, section, span, time, h1, p, etc.)
-- Never use class names as tag names.
-- Use `contains(@class, '...')` to target classes.
-- Always start with '//' or '/html' and separate each tag with '/'.
-
-Example:
-✅ //section[contains(@class, 'article-body')]//p/text()
-❌ /html/body/main/article/section/article-details-body-container/article-body
-
-CURRENT XPATH MAP:
-{_format_xpath_snapshot(state['global_state'])}
-
-FIELD STRATEGIES:
-{_format_field_strategies(state['global_state'])}
-
-CURRENT EXTRACTIONS SUMMARY:
-{formatted_extracts}
-
-HTML:
-{state['cleaned_html_content']}
-"""
+    extra_context = reasoner_config.get("context", {})
+    content = render_prompt_template(
+        template,
+        {
+            "formatted_extracts": formatted_extracts,
+            "xpath_snapshot": _format_xpath_snapshot(state["global_state"]),
+            "field_strategies": _format_field_strategies(state["global_state"]),
+            "html_content": state["cleaned_html_content"],
+            **extra_context,
+        },
     )
+
+    return SystemMessage(content=content)
+
 
 def get_formatted_extracts(current_extracts):
     lines = []


### PR DESCRIPTION
## Summary
- externalize the reasoner and summarizer prompts into configurable templates with field-aware placeholders
- add reusable prompt rendering utilities and config-driven context for the extraction reasoner
- refactor the summarizer node to load field mappings and allowed tags from configuration

## Testing
- python -m compileall langscrape

------
https://chatgpt.com/codex/tasks/task_e_68e105074748832c9bd32e48309d1653