### PR TITLE
Handle DeepSeek Reasoner responses

### DIFF
--- a/langscrape/nodes/extraction_reasoner.py
+++ b/langscrape/nodes/extraction_reasoner.py
@@ -1,7 +1,11 @@
 from langchain_core.messages import SystemMessage
 from ..html.xpath_extractor import extract_by_xpath_map_from_html
 from ..agent.state import AgentState
-from ..utils import get_system_prompt, get_formatted_extracts
+from ..utils import (
+    get_system_prompt,
+    get_formatted_extracts,
+    coerce_model_content_to_str,
+)
 
 def extraction_reasoner(state: AgentState) -> AgentState:
     state["iterations"] += 1
@@ -12,5 +16,22 @@ def extraction_reasoner(state: AgentState) -> AgentState:
     print(system_prompt.content)
     print("\n=== END OF PROMPT ===\n")
     response = state['extractor'].invoke([system_prompt] + state["messages"])
+
+    reasoning_raw = getattr(response, "additional_kwargs", {}).get("reasoning_content")
+    reasoning_text = coerce_model_content_to_str(reasoning_raw)
+
+    content_text = coerce_model_content_to_str(response.content)
+    if content_text != response.content:
+        response = response.model_copy(update={"content": content_text})
+
+    if reasoning_text:
+        print("=== 🤔 MODEL REASONING ===\n")
+        print(reasoning_text)
+        print("\n=== END OF REASONING ===\n")
+
+    print("=== 🗣️ MODEL RESPONSE ===\n")
+    print(content_text)
+    print("\n=== END OF RESPONSE ===\n")
+
     print("DEBUG tool_calls:", getattr(response, "tool_calls", None))
     return {"messages": [response]}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+from langscrape.utils import coerce_model_content_to_str
+
+
+def test_coerce_model_content_to_str_with_reasoner_blocks():
+    content = [
+        {"type": "reasoning", "text": "Step 1. "},
+        {"type": "reasoning", "text": ["Step 2. ", {"text": "Nested."}]},
+        {"type": "answer", "text": "Final answer"},
+    ]
+
+    assert coerce_model_content_to_str(content) == "Step 1. Step 2. Nested.Final answer"
+
+
+def test_coerce_model_content_to_str_dict_with_content_key():
+    content = {"content": ["Alpha", {"text": "Beta"}]}
+
+    assert coerce_model_content_to_str(content) == "AlphaBeta"


### PR DESCRIPTION
## Summary
- normalize model content so DeepSeek Reasoner responses collapse into plain text
- print reasoning and final responses separately when invoking the extraction node
- add unit coverage for the new content coercion helper

## Testing
- pytest tests/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e23d757834832cbac60de9775e6c05