### PR TITLE
Add centralized logging to Langscrape

### DIFF
--- a/langscrape/browser/chrome.py
+++ b/langscrape/browser/chrome.py
@@ -1,10 +1,15 @@
 import asyncio
+
 from patchright.async_api import async_playwright
+
+from ..logging import get_logger
 from ..utils import load_config
 
 config = load_config()
 
 USER_DATA_DIR = "/tmp/patchright-profile"
+
+logger = get_logger(__name__)
 
 async def fetch_html_patchright(url: str) -> str:
     """
@@ -27,14 +32,14 @@ async def fetch_html_patchright(url: str) -> str:
         )
 
         page = await browser.new_page()
-        print(f"Navigating to {url} ...")
+        logger.info("Navigating to %s ...", url)
         try:
             await page.goto(url)
             await page.wait_for_timeout(config['browser']['wait_for_timeout'])
             html = await page.content()
-            print(f"HTML fetched ({len(html)} chars)")
-        except Exception as e:
-            print(f"Failed to fetch: {e}")
+            logger.info("HTML fetched (%s chars)", len(html))
+        except Exception:
+            logger.exception("Failed to fetch %s", url)
             html = ""
         finally:
             await browser.close()

--- a/langscrape/logging.py
+++ b/langscrape/logging.py
@@ -1,0 +1,43 @@
+"""Centralized logging utilities for the Langscrape project."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional, Union
+
+_DEFAULT_LEVEL_NAME = os.getenv("LANGSCRAPE_LOG_LEVEL", "INFO")
+_DEFAULT_FORMAT = os.getenv(
+    "LANGSCRAPE_LOG_FORMAT",
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+
+
+def _resolve_level(level: Union[str, int]) -> int:
+    """Convert a log level name or integer to a ``logging`` level value."""
+    if isinstance(level, int):
+        return level
+
+    normalized = (level or "").upper()
+    return getattr(logging, normalized, logging.INFO)
+
+
+def _configure_root_logger() -> logging.Logger:
+    """Ensure the Langscrape root logger is configured exactly once."""
+    root_logger = logging.getLogger("langscrape")
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(_DEFAULT_FORMAT))
+        root_logger.addHandler(handler)
+
+    root_logger.setLevel(_resolve_level(_DEFAULT_LEVEL_NAME))
+    return root_logger
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger scoped to ``name`` using the shared Langscrape config."""
+    root_logger = _configure_root_logger()
+    if not name or name == "langscrape":
+        return root_logger
+    if name.startswith("langscrape."):
+        return logging.getLogger(name)
+    return root_logger.getChild(name)

--- a/langscrape/nodes/extraction_reasoner.py
+++ b/langscrape/nodes/extraction_reasoner.py
@@ -1,16 +1,22 @@
 from langchain_core.messages import SystemMessage
-from ..html.xpath_extractor import extract_by_xpath_map_from_html
+
 from ..agent.state import AgentState
+from ..html.xpath_extractor import extract_by_xpath_map_from_html
+from ..logging import get_logger
 from ..utils import get_system_prompt, get_formatted_extracts
+
+
+logger = get_logger(__name__)
 
 def extraction_reasoner(state: AgentState) -> AgentState:
     state["iterations"] += 1
     current_extracts = extract_by_xpath_map_from_html(state['cleaned_html_content'], state['global_state'])
     formatted_extracts = get_formatted_extracts(current_extracts)
     system_prompt = get_system_prompt(state, formatted_extracts)
-    print(f"\n=== 🧠 SYSTEM PROMPT (ITERATION: {state["iterations"]}) ===\n")
-    print(system_prompt.content)
-    print("\n=== END OF PROMPT ===\n")
+    logger.info("\n=== 🧠 SYSTEM PROMPT (ITERATION: %s) ===\n", state["iterations"])
+    logger.info(system_prompt.content)
+    logger.info("\n=== END OF PROMPT ===\n")
     response = state['extractor'].invoke([system_prompt] + state["messages"])
-    print("DEBUG tool_calls:", getattr(response, "tool_calls", None))
+    logger.debug("DEBUG tool_calls: %s", getattr(response, "tool_calls", None))
     return {"messages": [response]}
+

--- a/langscrape/printer.py
+++ b/langscrape/printer.py
@@ -1,14 +1,19 @@
 from .html.xpath_extractor import extract_by_xpath_map_from_html
+from .logging import get_logger
+
+
+logger = get_logger(__name__)
+
 
 def final_print(global_state, html_content):
 
     # 🎨 ANSI color codes
-    BLUE = "\033[94m"  
+    BLUE = "\033[94m"
     GREEN = "\033[92m"
     BOLD = "\033[1m"
     RESET = "\033[0m"
 
-    print(f"\n{BOLD}{BLUE}=== FINAL XPATH STATE ==={RESET}")
+    logger.info("\n%s%s=== FINAL XPATH STATE ===%s", BOLD, BLUE, RESET)
     for k, v in global_state.items():
         if isinstance(v, dict):
             strategy = v.get("strategy", "xpath_extractor")
@@ -16,14 +21,14 @@ def final_print(global_state, html_content):
                 detail = v.get("value")
             else:
                 detail = v.get("xpath")
-            print(f"{BLUE}{k}{RESET} ({strategy}): {detail}")
+            logger.info("%s%s%s (%s): %s", BLUE, k, RESET, strategy, detail)
         else:
-            print(f"{BLUE}{k}{RESET}: {v}")
+            logger.info("%s%s%s: %s", BLUE, k, RESET, v)
 
-    print(f"\n{BOLD}{GREEN}=== FINAL EXTRACTED CONTENT ==={RESET}")
+    logger.info("\n%s%s=== FINAL EXTRACTED CONTENT ===%s", BOLD, GREEN, RESET)
     results = extract_by_xpath_map_from_html(html_content, field_state=global_state)
     for k, v in results.items():
         joined = " | ".join(v)
-        print(f"{GREEN}{k}{RESET}: {joined}")
-    
+        logger.info("%s%s%s: %s", GREEN, k, RESET, joined)
+
     return None


### PR DESCRIPTION
## Summary
- add a reusable logging helper that centralizes configuration for Langscrape
- switch high-level browser, reasoning, and output modules from print statements to the shared logger for consistent diagnostics

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'dotenv'; ProxyError contacting mermaid.ink)*

------
https://chatgpt.com/codex/tasks/task_e_68e2766bc300832c9b7c8ae8cf80f536