### PR TITLE
Log token usage for summarizer and extractor

### DIFF
--- a/langscrape/agent/state.py
+++ b/langscrape/agent/state.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Annotated, Sequence, Union, Dict, Any
+from typing import TypedDict, Annotated, Sequence, Union, Dict, Any, NotRequired
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
 from langchain_openai import ChatOpenAI
@@ -20,3 +20,4 @@ class AgentState(TypedDict):
     extracted_fields: Dict[str, Any]
     summary: BaseMessage
     result: Dict[str, Any]
+    token_usage: NotRequired[Dict[str, Dict[str, int]]]

--- a/langscrape/nodes/extraction_reasoner.py
+++ b/langscrape/nodes/extraction_reasoner.py
@@ -1,7 +1,7 @@
 from langchain_core.messages import SystemMessage
 from ..html.xpath_extractor import extract_by_xpath_map_from_html
 from ..agent.state import AgentState
-from ..utils import get_system_prompt, get_formatted_extracts
+from ..utils import get_system_prompt, get_formatted_extracts, update_token_usage
 
 def extraction_reasoner(state: AgentState) -> AgentState:
     iters = state["iterations"]
@@ -14,4 +14,5 @@ def extraction_reasoner(state: AgentState) -> AgentState:
     response = state['extractor'].invoke([system_prompt] + state["messages"])
     print("DEBUG tool_calls:", getattr(response, "tool_calls", None))
     iters += 1
-    return {"messages": [response], "iterations": iters}
+    token_usage = update_token_usage(state, "extractor", response)
+    return {"messages": [response], "iterations": iters, "token_usage": token_usage}

--- a/langscrape/nodes/post_processor.py
+++ b/langscrape/nodes/post_processor.py
@@ -2,10 +2,8 @@ from ..agent.state import AgentState
 from ..json import SchemeValidator, JSON_SCHEME
 import json
 import os
-from langscrape.utils import load_config
+from langscrape.utils import load_config, get_default_token_usage
 from ..tags import LOCATIONS, FIGURES, COUNTRIES_AND_ORGANIZATIONS, THEME_TAGS
-from typing import List
-
 from typing import List
 
 
@@ -64,13 +62,35 @@ def post_processor(state: AgentState) -> AgentState:
         validation_report["all_data_keys_in_scheme"]
         and validation_report["all_scheme_keys_in_data"]
     )
-    state['result']['meta_data']["is_valid_scheme"] = is_valid
+    token_usage = state.get("token_usage") or get_default_token_usage()
+    meta_data = state['result'].setdefault('meta_data', {})
+    meta_data["is_valid_scheme"] = is_valid
+    meta_data["token_usage"] = token_usage
     output_dir = config.get("output_dir", "data")
     os.makedirs(output_dir, exist_ok=True)
     filename = state.get("url", "output").rstrip("/").split("/")[-1] or "output"
     output_path = os.path.join(output_dir, f"{filename}.json")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(state['result'], f, ensure_ascii=False, indent=2)
+    logging_path = os.path.join(output_dir, "logging.json")
+    if os.path.exists(logging_path):
+        try:
+            with open(logging_path, "r", encoding="utf-8") as log_file:
+                logging_data = json.load(log_file) or {}
+        except json.JSONDecodeError:
+            logging_data = {}
+    else:
+        logging_data = {}
+
+    log_key = state.get("id") or state.get("url") or filename
+    logging_data[str(log_key)] = {
+        "id": state.get("id"),
+        "url": state.get("url"),
+        "token_usage": token_usage,
+    }
+
+    with open(logging_path, "w", encoding="utf-8") as log_file:
+        json.dump(logging_data, log_file, ensure_ascii=False, indent=2)
     return {
         "result": {
             "meta_data": {

--- a/langscrape/nodes/summarizer.py
+++ b/langscrape/nodes/summarizer.py
@@ -1,8 +1,11 @@
-from ..agent.state import AgentState
-from ..tags import THEME_TAGS, COUNTRIES_AND_ORGANIZATIONS, LOCATIONS, FIGURES
-from ..json import JSON_SCHEME
-from langchain_core.messages import SystemMessage, HumanMessage
 import json
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from ..agent.state import AgentState
+from ..json import JSON_SCHEME
+from ..tags import COUNTRIES_AND_ORGANIZATIONS, FIGURES, LOCATIONS, THEME_TAGS
+from ..utils import update_token_usage
 
 def get_summarizer_system_prompt(state: AgentState) -> str:
     prompt_template = f"""Your task is to analyze the provided contens.
@@ -113,4 +116,5 @@ def summarizer(state: AgentState) -> AgentState:
         HumanMessage(content=get_user_prompt(state)),
     ]
     response = state["summarizer"].invoke(messages)
-    return {"summary": response}
+    token_usage = update_token_usage(state, "summarizer", response)
+    return {"summary": response, "token_usage": token_usage}


### PR DESCRIPTION
## Summary
- accumulate token usage for both the extractor and summarizer nodes and persist it in the agent state
- expose the collected token usage in the final result metadata and append it to `logging.json`

## Testing
- not run (requires external API credentials)


------
https://chatgpt.com/codex/tasks/task_e_68e60d36ee8c832ca228902133aa7a2f